### PR TITLE
compton: version bump (change upstream project)

### DIFF
--- a/packages/x11-apps/compton/compton-6.2.exheres-0
+++ b/packages/x11-apps/compton/compton-6.2.exheres-0
@@ -3,6 +3,5 @@
 
 require compton
 
-SLOT="0"
 PLATFORMS="~amd64"
 

--- a/packages/x11-apps/compton/compton-scm.exheres-0
+++ b/packages/x11-apps/compton/compton-scm.exheres-0
@@ -1,8 +1,19 @@
 # Copyright 2013, 2014 Lasse Brun <bruners@gmail.com>
 # Distributed under the terms of the GNU General Public License v2
 
+# Last checked: 5a034ea169cbbf04808061781f96f46a0e240eb3 (2019-06-23)
+GITHUB_BRANCH="next"
+
+SCM_EXTERNAL_REFS="subprojects/test.h:test_h"
+SCM_SECONDARY_REPOSITORIES="test_h"
+SCM_test_h_REPOSITORY="https://github.com/yshui/test.h"
+
 require compton
 
-SLOT="0"
 PLATFORMS="~amd64"
+
+DEPENDENCIES="
+    build+run:
+        dev-libs/uthash
+"
 

--- a/packages/x11-apps/compton/compton.exlib
+++ b/packages/x11-apps/compton/compton.exlib
@@ -1,15 +1,16 @@
 # Copyright 2013, 2014 Lasse Brun <bruners@gmail.com>
 # Distributed under the terms of the GNU General Public License v2
 
-require github [ user=chjj tag=v${PV} ]
+require github [ user=yshui tag=v${PV} ]
+require meson gtk-icon-cache
 
 SUMMARY="Compton is a X compositing manager, forked of xcompmgr-dana and xcompgmr"
 LICENCES="MIT"
+SLOT="0"
 MYOPTIONS="
     dbus        [[ description = [ Change VSync mode with D-Bus, needs testing ] ]]
-    libconfig   [[ description = [ Configuration for MIA qt-gui?, prefers 2.x, 1.4.x should work ] ]]
+    libconfig   [[ description = [ Enable config file support ] ]]
     opengl      [[ description = [ Opengl and VSync composition ] ]]
-    xinerama
 "
 
 DEPENDENCIES="
@@ -18,60 +19,57 @@ DEPENDENCIES="
         virtual/pkg-config
         x11-proto/xorgproto
     build+run:
+        dev-libs/libev
         dev-libs/pcre[>=8.10]
         x11-libs/libX11
-        x11-libs/libXcomposite
-        x11-libs/libXdamage
+        x11-libs/libxcb[>=1.9.2]
         x11-libs/libXext
-        x11-libs/libXfixes
-        x11-libs/libXrandr
-        x11-libs/libXrender
+        x11-libs/pixman:1
+        x11-utils/xcb-util-image
+        x11-utils/xcb-util-renderutil
+        dbus? ( sys-apps/dbus )
+        libconfig? (
+            dev-libs/libconfig[>=1.4]
+            x11-libs/libxdg-basedir
+        )
+        opengl? (
+            x11-dri/libdrm
+            x11-dri/mesa
+        )
     run:
         x11-apps/xprop
         x11-apps/xwininfo
-
-        dbus? ( sys-apps/dbus )
-        libconfig? ( dev-libs/libconfig )
-        opengl? ( x11-dri/mesa )
-        xinerama? ( x11-libs/libXinerama )
 "
 
 BUGS_TO="bruners@gmail.com"
 
-src_prepare() {
-    edo sed -e "s/pkg-config/$(exhost --tool-prefix)pkg-config/g" -i Makefile
+DEFAULT_SRC_PREPARE_PATCHES=(
+    "$FILES/scripts-destdir.patch"
+)
 
-    default
-}
+DEFAULT_SRC_INSTALL_EXTRA_DOCS=(
+    "${PN}.sample.conf"
+)
 
-src_compile() {
-    config=(
-        NO_REGEX_PCRE=false
-    )
-    # default enables and disables
-    option dbus || config+=( NO_DBUS=true )
-    option libconfig || config+=( NO_LIBCONFIG=true )
-    option opengl || config+=( NO_VSYNC_OPENGL=true NO_VSYNC_DRM=true )
-    option xinerama || config+=( NO_XINERAMA=true )
+MESON_SRC_CONFIGURE_PARAMS=(
+    "-Dbuild_docs=true"
+    "-Dregex=true"
+)
 
-    emake ${config[*]} ${PN}
-
-    # Build man pages
-    emake ${config[*]} docs
-}
+MESON_SRC_CONFIGURE_OPTION_SWITCHES=(
+    "dbus"
+    "libconfig config_file"
+    "opengl"
+    "opengl vsync_drm"
+)
 
 src_install() {
-    dobin "${PN}" bin/"${PN}"-trans
-
-    doman man/compton.1 man/compton-trans.1
-
-    dodoc -r man/compton.1.html man/compton-trans.1.html
-
-    dodoc README.md compton.sample.conf
+    meson_src_install
     option dbus && dodoc dbus-examples/cdbus-driver.sh
 }
 
 pkg_postinst() {
+    gtk-icon-cache_pkg_postinst
     elog "Sample configuration/tools for ${PN} can be found in /usr/share/doc/${PNV}"
     elog "compton.sample.conf - Sourced from XDG directories \$XDG_CONFIG_HOME/${PN}.conf \$HOME/.${PN}.conf"
     option dbus &&

--- a/packages/x11-apps/compton/files/scripts-destdir.patch
+++ b/packages/x11-apps/compton/files/scripts-destdir.patch
@@ -1,0 +1,26 @@
+Upstream: sent as https://github.com/yshui/compton/pull/195
+
+commit 87aafc1738babb6237df5de370ed56f60186a469
+Author: Alexander Kapshuna <kapsh@kap.sh>
+Date:   Sun Jun 23 12:17:04 2019 +0300
+
+    build: install scripts into bindir provided by meson
+
+    This will use --bindir value to install additional scripts into the same location
+    as compton binary (current behavior: hardcoded $prefix/bin).
+    Useful for custom installations and/or cross-compiling.
+
+diff --git a/meson.build b/meson.build
+index f8d5c84..0abe7a2 100644
+--- a/meson.build
++++ b/meson.build
+@@ -66,7 +66,8 @@ test_h_dep = subproject('test.h').get_variable('test_h_dep')
+ subdir('src')
+ subdir('man')
+
+-install_subdir('bin', install_dir: '')
++install_data(['bin/compton-convgen.py', 'bin/compton-trans'],
++             install_dir: get_option('bindir'))
+ install_data('compton.desktop', install_dir: 'share/applications')
+ install_data('media/icons/48x48/compton.png',
+              install_dir: 'share/icons/hicolor/48x48/apps')


### PR DESCRIPTION
Switch to maintained fork[1], upstream seems to be almost abandoned[2].
This project is already adopted as alternative by several distributions
like ArchLinux (with forks), Void, Alpine, etc.
xinerama option removed: fails to build and will be mandatory soon[3].

1. https://github.com/yshui/compton
2. https://github.com/chjj/compton/commits/master
3. https://github.com/yshui/compton/issues/116